### PR TITLE
prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [Unreleased] -->
 
-## [Unreleased]
+## [0.6.0] - 2023-12-08
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geodesy-wasm"
-version = "0.5.0"
+version = "0.6.0"
 rust-version = "1.70"
 keywords = ["geospatial", "geodesy", "cartography", "geography"]
 categories = ["science"]


### PR DESCRIPTION

## [0.6.0] - 2023-12-08

### Added

- Attribution for `OSTN15_NTv1_OSGBtoETRS.gsb` [#32](https://github.com/Rennzie/geodesy-wasm/issues/32)
- Support for 2D, 3D and 4D coordinates as tuples ([number, number]) or objects ({x, y, z, t}) to the wrapper
- Unstable support for loading a grid from the network
- Support for the `axisswap` operator via [Geodesy:#84](https://github.com/busstoptaktik/geodesy/pull/84)
- `senmerc` operator [#38](https://github.com/Rennzie/geodesy-wasm/issues/38)

### Changed

- Grids are stored in globally allocated heap memory [#34](https://github.com/Rennzie/geodesy-wasm/issues/34)
- Lazily initialise the operator so grids can be registered after creation
- Grids are loaded via standalone helper functions [#39](https://github.com/Rennzie/geodesy-wasm/issues/39)
- Renamed `noop` operator to `senmerc` in anticipation of adding a Sensat Mercator operator
- How Coordinates work [#19](https://github.com/Rennzie/geodesy-wasm/issues/19):
  - Rename `CoordBuffer` to `Coordinates`
  - Remove superfluous wrapping of the underlying buffer
  - Removed the requirement for specifying the coordinate dimension - they are always 4D.

### Removed

- The `unitconvert` and `longlat` operators which have been implemented upstream in [Geodesy:#80](https://github.com/busstoptaktik/geodesy/pull/80)